### PR TITLE
Reset internal timers on boot, to stop spurious interrupts.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,12 +65,11 @@ pub unsafe extern "C" fn Reset() -> ! {
 unsafe fn reset_internal_timers() {
     // TODO feature gate for silicon specific configurations
     llvm_asm!("
-        movi a2,0
-        wsr.ccompare0 a2
-        wsr.ccompare1 a2
-        wsr.ccompare2 a2
+        wsr.ccompare0 $0
+        wsr.ccompare1 $0
+        wsr.ccompare2 $0
         isync
-    " ::::: "volatile");
+    " ::"r"(0)::: "volatile");
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
I've been playing some more with interrupts, I've spotted that unmasking all interrupts causes interrupt 16 (INTERNAL_TIMER2) to fire instantly. According to the ISA the `ccomparen` an ccount registers are undefined on reset. This change removes the interrupt disable and instead resets the internal timer peripherals.

cc: @arjanmels Have you seen this behavior before? I'm guessing you have based on the interrupt mask line you put in originally?