### PR TITLE
Fix text sections for default exception handlers.

### DIFF
--- a/src/exception.rs
+++ b/src/exception.rs
@@ -31,6 +31,7 @@ mod assembly;
 ///
 #[allow(unused)]
 #[derive(Debug)]
+#[repr(C)]
 pub enum ExceptionCause {
     /// Illegal Instruction
     Illegal = 0,

--- a/xtensa.in.x
+++ b/xtensa.in.x
@@ -127,6 +127,12 @@ SECTIONS {
     *(.noinit .noinit.*)
   } > RWDATA
 
+  .rwtext :
+  {
+    . = ALIGN (4);
+    *(.rwtext.literal .rwtext .rwtext.literal.* .rwtext.*)
+  } > RWTEXT
+
  /* must be last segment using RWTEXT */
   .text_heap_start (NOLOAD) :
   {


### PR DESCRIPTION
I believe this is a simple oversight, as `rwtext` only exists in the esp32-hal.

Without this change, building an app without esp32-hal would through linker errors.